### PR TITLE
Add date picker to Admin semester add/edit pages

### DIFF
--- a/src/views/AdminSemAdd.vue
+++ b/src/views/AdminSemAdd.vue
@@ -49,6 +49,7 @@ function cancel() {
             label=""
             v-model="semester.startDate"
             :rules="dateRules"
+            type="date"
           ></v-text-field>
           <p class="pl-5" style="font-weight: bold">End Date</p>
           <v-text-field
@@ -56,6 +57,7 @@ function cancel() {
             label=""
             v-model="semester.endDate"
             :rules="dateRules"
+            type="date"
           ></v-text-field>
         </div>
       </div>

--- a/src/views/AdminSemAdd.vue
+++ b/src/views/AdminSemAdd.vue
@@ -12,10 +12,6 @@ let semesterRules = [
 
 let dateRules = [
   (value) => !!value || "Date is required",
-  (value) =>
-    /^(0?[1-9]|1[1,2])(\/|-)(0?[1-9]|[12][0-9]|3[01])(\/|-)(19|20)\d{2}/.test(
-      value
-    ) || "Use DD/MM/YYYY must be valid",
 ];
 
 function save() {

--- a/src/views/AdminSemEdit.vue
+++ b/src/views/AdminSemEdit.vue
@@ -17,10 +17,6 @@ let semesterRules = [
 
 let dateRules = [
   (value) => !!value || "Date is required",
-  (value) =>
-    /^(0?[1-9]|1[1,2])(\/|-)(0?[1-9]|[12][0-9]|3[01])(\/|-)(19|20)\d{2}/.test(
-      value
-    ) || "Use DD/MM/YYYY must be valid",
 ];
 
 onMounted(async () => {
@@ -30,12 +26,12 @@ onMounted(async () => {
 
       semester.value.startDate =
         semester.value.startDate != null
-          ? new Date(semester.value.startDate).toLocaleDateString()
-          : null;
+  ? new Date(semester.value.startDate).toISOString().split('T')[0]
+  : null;
 
       semester.value.endDate =
         semester.value.endDate != null
-          ? new Date(semester.value.endDate).toLocaleDateString()
+          ? new Date(semester.value.endDate).toISOString().split('T')[0]
           : null;
     })
     .catch((err) => {
@@ -74,6 +70,7 @@ function cancel() {
           label=""
           v-model="semester.startDate"
           :rules="dateRules"
+          type="date"
         ></v-text-field>
         <p class="pl-5" style="font-weight: bold">End Date</p>
         <v-text-field
@@ -81,6 +78,7 @@ function cancel() {
           label=""
           v-model="semester.endDate"
           :rules="dateRules"
+          type="date"
         ></v-text-field>
       </div>
     </v-card>

--- a/src/views/AdminSemManage.vue
+++ b/src/views/AdminSemManage.vue
@@ -21,9 +21,9 @@ onMounted(async () => {
 });
 
 function deleteSem(semesterId) {
-  SemesterServices.delete(semesterId)
+  SemesterServices.deleteSemester(semesterId)
     .then(() => {
-      router.go();
+      getSemesters();
     })
     .catch((error) => {
       console.error("Error deleting semester:", error);


### PR DESCRIPTION
added date picker to both adminSemAdd and adminSemEdit. 
The admin can now select a date directly from date picker instead of entering it manually.
I removed the regex validation for date format, assuming that the date picker will always provide a valid date in the correct format.